### PR TITLE
Reduce the Flatpak size

### DIFF
--- a/org.kde.kaffeine.json
+++ b/org.kde.kaffeine.json
@@ -23,6 +23,14 @@
         "--system-talk-name=org.freedesktop.UDisks2",
         "--system-talk-name=org.freedesktop.UPower"
     ],
+     "cleanup": [
+        "/include",
+        "/lib/pkgconfig",
+        "/share/doc",
+        "/share/man",
+        "*.la",
+        "*.a"
+    ],
     "modules": [
         {
             "name": "libdvdread",


### PR DESCRIPTION
The installed size reduced from 59.9 MB to 30.7 MB.

KDE apps usually open an external website for help documentation.

Therefore, it's not required to keep the /share/doc folder.